### PR TITLE
fix: metric name clash issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,13 +475,8 @@ parameters related to [log configuration](#log-configuration).
 | A prefix to prepend to Bitmovin metric names | string | N | `''` |
 
 This parameter specifies a prefix that will be preprended to each Bitmovin
-metric name when the metric is exported to New Relic. Note that this is
-_in addition_ to the automatically prepended prefixes added to distinguish
-between the aggregation functions used for a query (e.g. `cnt`, `avg`, etc).
-
-For example, if this parameter is set to `bitmovin.`, for a `count` query run
-for the `IMPRESSION_ID` metric, the resulting metric name in New Relic would be
-`bitmovin.cnt_impression_id`.
+metric name when the metric is exported to New Relic. For more information
+on metric naming see the [query name](#query-name) paremeter.
 
 ###### `bitmovinApiKey`
 
@@ -811,13 +806,21 @@ See the [Query Examples section](#query-examples) for example usages.
 | --- | --- | --- | --- |
 | Metric name. | string | N | N/a |
 
-This parameter specifies the metric name for a given query. If present, it has precedence over the default name
-generated using [`type`](#query-type) and [`metric`](#query-metric), and the final metric name is generated using the [`metric prefix`](#bitmovinmetricprefix)
-plus the `name` parameter.
+This parameter specifies the metric name for a given query. When present, the final metric name is generated using the
+[`metric prefix`](#bitmovinmetricprefix) plus the `name` parameter. For example, if `bitmovinMetricPrefix` is `bitmovin.`
+and `name` is `count_views`, the final metric name sent to New Relic will be `bitmovin.count_views`.
+
+Although optional, this parameter is **highly recommended**. A config file can contain multiple queries with the same `type`
+and `metric`, but different dimensions, filters, order-by, etc. Since the metric name is automatically generated only
+using the pair `type` and `metric`, this could cause the collision of multiple different Bitmovin metrics, being
+sent to New Relic with the same name. The legacy way of automatically generating metric names (described in the [next section](#bitmovin-to-new-relic-metric-mapping))
+is kept for backwards compatibility, but it's deprecated and will be eventually removed.
 
 ###### Bitmovin to New Relic metric mapping
 
-> NOTE: The information exposed below only applies if the [`name`](#query-name) parameter is not specified.
+> [!WARNING]
+> This mechanism for metric naming is **deprecated**.
+> The information exposed in this section only applies if the [`name`](#query-name) parameter is not specified.
 
 Metrics returned from the Bitmovin API are all mapped to
 [New Relic gauge metrics](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/metric-data-type/)
@@ -854,6 +857,7 @@ queries:
 # ...
 - type: count
   metric: IMPRESSION_ID
+  name: count_impressions
   filters:
     VIDEO_STARTUPTIME:
       operator: GT
@@ -867,6 +871,7 @@ queries:
 # ...
 - type: count
   metric: PLAY_ATTEMPTS
+  name: count_play_attempts
 ```
 
 **[Unique Users](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#unique-users)**
@@ -876,6 +881,7 @@ queries:
 # ...
 - type: count
   metric: USER_ID
+  name: count_users
   filters:
     VIDEO_STARTUPTIME:
       operator: GT
@@ -888,6 +894,7 @@ queries:
 queries:
 # ...
 - type: max_concurrentviewers
+  name: max_viewers
 ```
 
 **[Total Page Loads](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#total-page-loads)**
@@ -897,6 +904,7 @@ queries:
 # ...
 - type: count
   metric: IMPRESSION_ID
+  name: count_impressions
   filters:
     PLAYER_STARTUPTIME:
       operator: GT
@@ -910,6 +918,7 @@ queries:
 # ...
 - type: sum
   metric: PLAYED
+  name: sum_played
   filters:
     PLAYED:
       operator: GT
@@ -923,6 +932,7 @@ queries:
 # ...
 - type: average
   metric: VIEWTIME
+  name: avrg_viewtime
 ```
 
 The following examples show how to recreate each of the [Quality of Experience metrics](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#quality-of-experience)
@@ -935,6 +945,7 @@ queries:
 # ...
 - type: median
   metric: STARTUPTIME
+  name: median_startup
   filters:
     PAGE_LOAD_TYPE:
       operator: EQ
@@ -951,6 +962,7 @@ queries:
 # ...
 - type: median
   metric: PLAYER_STARTUPTIME
+name: median_player_startup
   filters:
     PAGE_LOAD_TYPE:
       operator: EQ
@@ -967,6 +979,7 @@ queries:
 # ...
 - type: median
   metric: VIDEO_STARTUPTIME
+  name: median_video_startup
   filters:
     VIDEO_STARTUPTIME:
       operator: GT
@@ -980,6 +993,7 @@ queries:
 # ...
 - type: median
   metric: SEEKED
+  name: median_seeked
   filters:
     SEEKED:
       operator: GT
@@ -993,6 +1007,7 @@ queries:
 # ...
 - type: average
   metric: ERROR_PERCENTAGE
+  name: avrg_error
 ```
 
 **[Start Failures](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#start-failures)**
@@ -1002,6 +1017,7 @@ queries:
 # ...
 - type: count
   metric: VIDEOSTART_FAILED
+  name: count_video_start_failures
   filters:
     VIDEOSTART_FAILED_REASON:
       operator: NE
@@ -1018,6 +1034,7 @@ queries:
 # ...
 - type: average
   metric: REBUFFER_PERCENTAGE
+  name: avrg_rebuffer
 ```
 
 **[Buffering Time](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#buffering-time)**
@@ -1027,6 +1044,7 @@ queries:
 # ...
 - type: average
   metric: BUFFERED
+  name: avrg_buffered
 ```
 
 **[Data Downloaded](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#data-downloaded)**
@@ -1036,6 +1054,7 @@ queries:
 # ...
 - type: sum
   metric: VIDEO_SEGMENTS_DOWNLOAD_SIZE
+  name: sum_video_segments_size
 ```
 
 **[Bandwidth](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#bandwidth)**
@@ -1045,6 +1064,7 @@ queries:
 # ...
 - type: average
   metric: DOWNLOAD_SPEED
+  name: avrg_speed
 ```
 
 **[Video Bitrate](https://developer.bitmovin.com/playback/docs/how-to-recreate-dashboard-queries-via-the-api-1#video-bitrate)**
@@ -1054,6 +1074,7 @@ queries:
 # ...
 - type: average
   metric: VIDEO_BITRATE
+  name: avrg_bitrate
   filters:
     VIDEO_BITRATE:
       operator: GT
@@ -1067,6 +1088,7 @@ queries:
 # ...
 - type: average
   metric: SCALE_FACTOR
+  name: avrg_scale
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -805,7 +805,19 @@ values are supported.
 
 See the [Query Examples section](#query-examples) for example usages.
 
+###### Query `name`
+
+| Description | Valid Values | Required | Default |
+| --- | --- | --- | --- |
+| Metric name. | string | N | N/a |
+
+This parameter specifies the metric name for a given query. If present, it has precedence over the default name
+generated using [`type`](#query-type) and [`metric`](#query-metric), and the final metric name is generated using the [`metric prefix`](#bitmovinmetricprefix)
+plus the `name` parameter.
+
 ###### Bitmovin to New Relic metric mapping
+
+> NOTE: The information exposed below only applies if the [`name`](#query-name) parameter is not specified.
 
 Metrics returned from the Bitmovin API are all mapped to
 [New Relic gauge metrics](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/metric-data-type/)

--- a/cmd/bitmovin-lambda/bitmovin-lambda.go
+++ b/cmd/bitmovin-lambda/bitmovin-lambda.go
@@ -13,7 +13,7 @@ var (
 	/* Args below are populated via ldflags at build time */
 	gIntegrationID      = "com.newrelic.labs.newrelic-bitmovin-analytics"
 	gIntegrationName    = "New Relic Bitmovin Analytics Integration Lambda"
-	gIntegrationVersion = "2.1.0"
+	gIntegrationVersion = "2.2.0"
 	gGitCommit          = ""
 	gBuildDate          = ""
 	gBuildInfo          = integration.BuildInfo{

--- a/cmd/bitmovin-lambda/bitmovin-lambda.go
+++ b/cmd/bitmovin-lambda/bitmovin-lambda.go
@@ -16,7 +16,7 @@ var (
 	gIntegrationVersion = "2.1.0"
 	gGitCommit          = ""
 	gBuildDate          = ""
-	gBuildInfo			= integration.BuildInfo{
+	gBuildInfo          = integration.BuildInfo{
 		Id:        gIntegrationID,
 		Name:      gIntegrationName,
 		Version:   gIntegrationVersion,
@@ -26,13 +26,13 @@ var (
 )
 
 type BitmovinLambdaResult struct {
-  Success           bool
-  Message           error
+	Success bool
+	Message error
 }
 
 func HandleRequest(ctx context.Context, event any) (
-  BitmovinLambdaResult,
-  error,
+	BitmovinLambdaResult,
+	error,
 ) {
 	// Create the integration with options
 	i, err := integration.NewLambdaIntegration(
@@ -43,27 +43,27 @@ func HandleRequest(ctx context.Context, event any) (
 	)
 	if err != nil {
 		log.Errorf("failed to create integration: %v", err)
-		return BitmovinLambdaResult{ false, err }, err
+		return BitmovinLambdaResult{false, err}, err
 	}
 
 	err = bitmovin.InitPipelines(i)
 	if err != nil {
 		log.Errorf("failed to initialize pipelines: %v", err)
-		return BitmovinLambdaResult{ false, err }, err
+		return BitmovinLambdaResult{false, err}, err
 	}
 
 	// Run the integration
 	defer i.Shutdown(ctx)
 
- 	err = i.Run(ctx)
+	err = i.Run(ctx)
 	if err != nil {
 		log.Errorf("integration failed: %v", err)
-		return BitmovinLambdaResult{ false, err }, err
+		return BitmovinLambdaResult{false, err}, err
 	}
 
-  return BitmovinLambdaResult{true, nil}, nil
+	return BitmovinLambdaResult{true, nil}, nil
 }
 
 func main() {
-  lambda.Start(HandleRequest)
+	lambda.Start(HandleRequest)
 }

--- a/cmd/bitmovin/bitmovin.go
+++ b/cmd/bitmovin/bitmovin.go
@@ -15,7 +15,7 @@ var (
 	gIntegrationVersion = "2.1.0"
 	gGitCommit          = ""
 	gBuildDate          = ""
-	gBuildInfo			= integration.BuildInfo{
+	gBuildInfo          = integration.BuildInfo{
 		Id:        gIntegrationID,
 		Name:      gIntegrationName,
 		Version:   gIntegrationVersion,
@@ -42,7 +42,7 @@ func main() {
 
 	// Run the integration
 	defer i.Shutdown(ctx)
- 	err = i.Run(ctx)
+	err = i.Run(ctx)
 	fatalIfErr(err)
 }
 

--- a/cmd/bitmovin/bitmovin.go
+++ b/cmd/bitmovin/bitmovin.go
@@ -12,7 +12,7 @@ var (
 	/* Args below are populated via ldflags at build time */
 	gIntegrationID      = "com.newrelic.labs.newrelic-bitmovin-analytics"
 	gIntegrationName    = "New Relic Bitmovin Analytics Integration"
-	gIntegrationVersion = "2.1.0"
+	gIntegrationVersion = "2.2.0"
 	gGitCommit          = ""
 	gBuildDate          = ""
 	gBuildInfo          = integration.BuildInfo{

--- a/configs/standard-config.yml
+++ b/configs/standard-config.yml
@@ -18,12 +18,16 @@ bitmovinTimeout: 30
 queries:
 ## Default Queries
 - type: max_concurrentviewers
+  name: max_concurrent_viewers
 - type: average
   metric: REBUFFER_PERCENTAGE
+  name: avrg_rebuff_percent
 - type: count
   metric: PLAY_ATTEMPTS
+  name: count_play_attempts
 - type: count
   metric: IMPRESSION_ID
+  name: count_impression_id
   filters:
     VIDEOSTART_FAILED_REASON:
       operator: NE
@@ -33,6 +37,7 @@ queries:
       value: true
 - type: count
   metric: VIDEO_STARTUPTIME
+  name: count_video_startup_time
   filters:
     VIDEO_STARTUPTIME:
       operator: GT
@@ -42,12 +47,14 @@ queries:
       value: 1
 - type: average
   metric: VIDEO_BITRATE
+  name: avrg_video_bitrate
   filters:
     VIDEO_BITRATE:
       operator: GT
       value: 0
 - type: average
   metric: VIEWTIME
+  name: avrg_view_time
   orderBy:
   - name: FUNCTION
     order: DESC

--- a/internal/bitmovin/model.go
+++ b/internal/bitmovin/model.go
@@ -1,9 +1,9 @@
 package bitmovin
 
 type BitmovinCredentials struct {
-	apiKey			string
-	licenseKey		string
-	tenantOrg		string
+	apiKey     string
+	licenseKey string
+	tenantOrg  string
 }
 
 type BitmovinQueryParams struct {
@@ -13,10 +13,10 @@ type BitmovinQueryParams struct {
 	BMDimension string
 	Metric      string
 	Filters     []map[string]any
-	GroupBy		[]string
+	GroupBy     []string
 	OrderBy     []BitmovinOrderBy
 	Interval    string
-	Percentile	*int64
+	Percentile  *int64
 }
 
 type BitmovinColumn struct {
@@ -27,11 +27,11 @@ type BitmovinColumn struct {
 type BitmovinRowData []any
 
 type BitmovinResult struct {
-	RowCount     int       `json:"rowCount"`
+	RowCount     int               `json:"rowCount"`
 	Rows         []BitmovinRowData `json:"rows"`
 	ColumnLabels []BitmovinColumn  `json:"columnLabels"`
-	JobID        string    `json:"jobId"`
-	TaskCount    int       `json:"taskCount"`
+	JobID        string            `json:"jobId"`
+	TaskCount    int               `json:"taskCount"`
 }
 
 type BitmovinMessage struct {
@@ -47,10 +47,10 @@ type BitmovinData struct {
 }
 
 type BitmovinResponse struct {
-	RequestID string `json:"requestId"`
-	Status    string `json:"status"`
-	Data      BitmovinData   `json:"data"`
-	Metric    string `json:"metric"`
+	RequestID string       `json:"requestId"`
+	Status    string       `json:"status"`
+	Data      BitmovinData `json:"data"`
+	Metric    string       `json:"metric"`
 }
 
 type BitmovinOrderBy struct {
@@ -59,29 +59,29 @@ type BitmovinOrderBy struct {
 }
 
 type BitmovinRequestBody struct {
-	Start      string            	`json:"start"`
-	End        string            	`json:"end"`
-	LicenseKey string            	`json:"licenseKey"`
-	Dimension  *string           	`json:"dimension,omitempty"`
-	Metric     *string           	`json:"metric,omitempty"`
-	Filters    *[]map[string]any 	`json:"filters,omitempty"`
-	GroupBy	   *[]string		 	`json:"groupBy,omitempty"`
-	OrderBy    *[]BitmovinOrderBy  	`json:"orderBy,omitempty"`
-	Interval   *string           	`json:"interval,omitempty"`
-	Percentile *int64				`json:"percentile,omitempty"`
+	Start      string             `json:"start"`
+	End        string             `json:"end"`
+	LicenseKey string             `json:"licenseKey"`
+	Dimension  *string            `json:"dimension,omitempty"`
+	Metric     *string            `json:"metric,omitempty"`
+	Filters    *[]map[string]any  `json:"filters,omitempty"`
+	GroupBy    *[]string          `json:"groupBy,omitempty"`
+	OrderBy    *[]BitmovinOrderBy `json:"orderBy,omitempty"`
+	Interval   *string            `json:"interval,omitempty"`
+	Percentile *int64             `json:"percentile,omitempty"`
 }
 
 type BitmovinFilter struct {
 	Operator string
-	Value any
+	Value    any
 }
 
 type BitmovinQuery struct {
-	Type 		string 						`json:"type"`
-	Metric 		string 						`json:"metric"`
-	Interval 	*string 					`json:"interval,omitempty"`
-	Dimensions 	*[]string 					`json:"dimensions,omitempty"`
-	Filters 	*map[string]BitmovinFilter 	`json:"filters,omitempty"`
-	OrderBy    	*[]BitmovinOrderBy  		`json:"orderBy,omitempty"`
-	Percentile	*int64						`json:"percentile,omitempty"`
+	Type       string                     `json:"type"`
+	Metric     string                     `json:"metric"`
+	Interval   *string                    `json:"interval,omitempty"`
+	Dimensions *[]string                  `json:"dimensions,omitempty"`
+	Filters    *map[string]BitmovinFilter `json:"filters,omitempty"`
+	OrderBy    *[]BitmovinOrderBy         `json:"orderBy,omitempty"`
+	Percentile *int64                     `json:"percentile,omitempty"`
 }

--- a/internal/bitmovin/model.go
+++ b/internal/bitmovin/model.go
@@ -79,6 +79,7 @@ type BitmovinFilter struct {
 type BitmovinQuery struct {
 	Type       string                     `json:"type"`
 	Metric     string                     `json:"metric"`
+	Name       string                     `json:"name"`
 	Interval   *string                    `json:"interval,omitempty"`
 	Dimensions *[]string                  `json:"dimensions,omitempty"`
 	Filters    *map[string]BitmovinFilter `json:"filters,omitempty"`

--- a/internal/bitmovin/receiver.go
+++ b/internal/bitmovin/receiver.go
@@ -215,8 +215,16 @@ func bitmovinResponseDecoderBuilder(
 				continue
 			}
 
+			var metricName string
+
+			if queryParams.Name == "" {
+				metricName = fmt.Sprintf("%s%s", metricPrefix, queryParams.NRMetric)
+			} else {
+				metricName = fmt.Sprintf("%s%s", metricPrefix, queryParams.Name)
+			}
+
 			metric := model.NewGaugeMetric(
-				fmt.Sprintf("%s%s", metricPrefix, queryParams.NRMetric),
+				metricName,
 				model.MakeNumeric(val),
 				time.Unix(int64(timestamp/1000), 0),
 			)
@@ -326,6 +334,7 @@ func addReceiverWithQuery(
 	switch query.Type {
 	case "max_concurrentviewers":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/metrics/max_concurrentviewers",
 			NRMetric:    "max_concurrent_viewers",
 			Metric:      "max_concurrentviewers",
@@ -337,6 +346,7 @@ func addReceiverWithQuery(
 		}
 	case "avg_concurrentviewers":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/metrics/avg_concurrentviewers",
 			NRMetric:    "avg_concurrent_viewers",
 			Metric:      "avg_concurrentviewers",
@@ -348,6 +358,7 @@ func addReceiverWithQuery(
 		}
 	case "avg_dropped_frames":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/metrics/avg_dropped_frames",
 			NRMetric:    "avg_dropped_frames",
 			Metric:      "avg_dropped_frames",
@@ -359,6 +370,7 @@ func addReceiverWithQuery(
 		}
 	case "count":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/count",
 			NRMetric:    fmt.Sprintf("cnt_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -370,6 +382,7 @@ func addReceiverWithQuery(
 		}
 	case "sum":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/sum",
 			NRMetric:    fmt.Sprintf("sum_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -381,6 +394,7 @@ func addReceiverWithQuery(
 		}
 	case "average":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/avg",
 			NRMetric:    fmt.Sprintf("avg_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -392,6 +406,7 @@ func addReceiverWithQuery(
 		}
 	case "min":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/min",
 			NRMetric:    fmt.Sprintf("min_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -403,6 +418,7 @@ func addReceiverWithQuery(
 		}
 	case "max":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/max",
 			NRMetric:    fmt.Sprintf("max_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -414,6 +430,7 @@ func addReceiverWithQuery(
 		}
 	case "stddev":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/stddev",
 			NRMetric:    fmt.Sprintf("stddev_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -426,6 +443,7 @@ func addReceiverWithQuery(
 	case "percentile":
 		// @TODO: add percentile
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/percentile",
 			NRMetric:    fmt.Sprintf("p%d_%s", *query.Percentile, strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -439,6 +457,7 @@ func addReceiverWithQuery(
 	case "variance":
 		// @TODO: add percentile
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/variance",
 			NRMetric:    fmt.Sprintf("var_%s", strings.ToLower(query.Metric)),
 			Metric:      "",
@@ -450,6 +469,7 @@ func addReceiverWithQuery(
 		}
 	case "median":
 		queryParams = &BitmovinQueryParams{
+			Name:        query.Name,
 			URI:         "/v1/analytics/queries/median",
 			NRMetric:    fmt.Sprintf("med_%s", strings.ToLower(query.Metric)),
 			Metric:      "",

--- a/internal/bitmovin/receiver.go
+++ b/internal/bitmovin/receiver.go
@@ -327,9 +327,14 @@ func addReceiverWithQuery(
 	licenseKey string,
 	metricPrefix string,
 	recvInterval time.Duration,
+	queryPos int,
 	query *BitmovinQuery,
 ) error {
 	var queryParams *BitmovinQueryParams
+
+	if query.Name == "" {
+		log.Warnf("automatic metric names are DEPRECATED, add a 'name' parameter in your config for the query at position %d", queryPos+1)
+	}
 
 	switch query.Type {
 	case "max_concurrentviewers":
@@ -503,14 +508,15 @@ func setupReceivers(
 	metricPrefix := viper.GetString("bitmovinMetricPrefix")
 	authenticator := NewBitmovinAuthenticator(credentials)
 
-	for _, query := range queries {
+	for pos := range queries {
 		err := addReceiverWithQuery(
 			mp,
 			authenticator,
 			credentials.licenseKey,
 			metricPrefix,
 			recvInterval,
-			&query,
+			pos,
+			&queries[pos],
 		)
 		if err != nil {
 			return err

--- a/internal/bitmovin/receiver.go
+++ b/internal/bitmovin/receiver.go
@@ -333,7 +333,7 @@ func addReceiverWithQuery(
 	var queryParams *BitmovinQueryParams
 
 	if query.Name == "" {
-		log.Warnf("automatic metric names are DEPRECATED, add a 'name' parameter in your config for the query at position %d", queryPos+1)
+		log.Warnf("automatic metric names are DEPRECATED, add a 'name' parameter to your config file for the query at position %d", queryPos+1)
 	}
 
 	switch query.Type {

--- a/internal/bitmovin/receiver.go
+++ b/internal/bitmovin/receiver.go
@@ -18,17 +18,15 @@ import (
 
 const (
 	DEFAULT_NULL_VALUE_STRING = "<NULL>"
-	BaseURL = "https://api.bitmovin.com"
+	BaseURL                   = "https://api.bitmovin.com"
 )
 
 type BitmovinAuthenticator struct {
-	credentials 		*BitmovinCredentials
+	credentials *BitmovinCredentials
 }
 
-func NewBitmovinAuthenticator(credentials *BitmovinCredentials) (
-	*BitmovinAuthenticator,
-) {
-	return &BitmovinAuthenticator{ credentials }
+func NewBitmovinAuthenticator(credentials *BitmovinCredentials) *BitmovinAuthenticator {
+	return &BitmovinAuthenticator{credentials}
 }
 
 func (b *BitmovinAuthenticator) Authenticate(
@@ -48,7 +46,7 @@ func bitmovinPostBodyBuilder(
 	queryParams *BitmovinQueryParams,
 	recvInterval time.Duration,
 ) connectors.HttpBodyBuilder {
-	return func () (any, error) {
+	return func() (any, error) {
 		end := time.Now().UTC()
 		bufferDuration := time.Duration(recvInterval + 60)
 		start := end.Add(-bufferDuration * time.Second)
@@ -102,13 +100,11 @@ func bitmovinPostBodyBuilder(
 func bitmovinResponseDecoderBuilder(
 	queryParams *BitmovinQueryParams,
 	metricPrefix string,
-) (
-	pipeline.MetricsDecoderFunc,
-) {
+) pipeline.MetricsDecoderFunc {
 	return func(
 		receiver pipeline.MetricsReceiver,
 		in io.ReadCloser,
-		out chan <- model.Metric,
+		out chan<- model.Metric,
 	) error {
 		apiResponse := BitmovinResponse{}
 
@@ -136,7 +132,7 @@ func bitmovinResponseDecoderBuilder(
 		}
 
 		// Generate the metrics
-		LOOP:
+	LOOP:
 
 		for i := 0; i < len(apiResponse.Data.Result.Rows); i += 1 {
 			colCount := len(apiResponse.Data.Result.Rows[i])
@@ -226,7 +222,7 @@ func bitmovinResponseDecoderBuilder(
 			)
 
 			if len(dimensions) > 0 {
-				for k, v := range(dimensions) {
+				for k, v := range dimensions {
 					metric.Attributes[k] = v
 				}
 			}
@@ -254,7 +250,7 @@ func addReceiver(
 	mp.AddReceiver(
 		pipeline.NewSimpleReceiver(
 			id,
-			BaseURL + queryParams.URI,
+			BaseURL+queryParams.URI,
 			pipeline.WithAuthenticator(authenticator),
 			pipeline.WithMethod("POST"),
 			pipeline.WithBody(bitmovinPostBodyBuilder(
@@ -266,7 +262,7 @@ func addReceiver(
 				queryParams,
 				metricPrefix,
 			)),
-			pipeline.WithTimeout(time.Duration(timeout) * time.Second),
+			pipeline.WithTimeout(time.Duration(timeout)*time.Second),
 		),
 	)
 }
@@ -279,10 +275,10 @@ func buildFilters(query *BitmovinQuery) []map[string]any {
 	}
 
 	for k, v := range *query.Filters {
-		filters = append(filters, map[string]any {
-			"name": strings.ToUpper(k),
+		filters = append(filters, map[string]any{
+			"name":     strings.ToUpper(k),
 			"operator": strings.ToUpper(v.Operator),
-			"value": v.Value,
+			"value":    v.Value,
 		})
 	}
 
@@ -330,138 +326,138 @@ func addReceiverWithQuery(
 	switch query.Type {
 	case "max_concurrentviewers":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/metrics/max_concurrentviewers",
-			NRMetric:    	"max_concurrent_viewers",
-			Metric:		 	"max_concurrentviewers",
-			BMDimension: 	"",
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/metrics/max_concurrentviewers",
+			NRMetric:    "max_concurrent_viewers",
+			Metric:      "max_concurrentviewers",
+			BMDimension: "",
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "avg_concurrentviewers":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/metrics/avg_concurrentviewers",
-			NRMetric:    	"avg_concurrent_viewers",
-			Metric:		 	"avg_concurrentviewers",
-			BMDimension: 	"",
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/metrics/avg_concurrentviewers",
+			NRMetric:    "avg_concurrent_viewers",
+			Metric:      "avg_concurrentviewers",
+			BMDimension: "",
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "avg_dropped_frames":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/metrics/avg_dropped_frames",
-			NRMetric:    	"avg_dropped_frames",
-			Metric:		 	"avg_dropped_frames",
-			BMDimension: 	"",
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/metrics/avg_dropped_frames",
+			NRMetric:    "avg_dropped_frames",
+			Metric:      "avg_dropped_frames",
+			BMDimension: "",
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "count":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/count",
-			NRMetric:    	fmt.Sprintf("cnt_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/count",
+			NRMetric:    fmt.Sprintf("cnt_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "sum":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/sum",
-			NRMetric:    	fmt.Sprintf("sum_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/sum",
+			NRMetric:    fmt.Sprintf("sum_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "average":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/avg",
-			NRMetric:    	fmt.Sprintf("avg_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/avg",
+			NRMetric:    fmt.Sprintf("avg_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "min":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/min",
-			NRMetric:    	fmt.Sprintf("min_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/min",
+			NRMetric:    fmt.Sprintf("min_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "max":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/max",
-			NRMetric:    	fmt.Sprintf("max_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/max",
+			NRMetric:    fmt.Sprintf("max_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "stddev":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/stddev",
-			NRMetric:    	fmt.Sprintf("stddev_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/stddev",
+			NRMetric:    fmt.Sprintf("stddev_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "percentile":
 		// @TODO: add percentile
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/percentile",
-			NRMetric:    	fmt.Sprintf("p%d_%s", *query.Percentile, strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
-			Percentile:		query.Percentile,
+			URI:         "/v1/analytics/queries/percentile",
+			NRMetric:    fmt.Sprintf("p%d_%s", *query.Percentile, strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
+			Percentile:  query.Percentile,
 		}
 	case "variance":
 		// @TODO: add percentile
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/variance",
-			NRMetric:    	fmt.Sprintf("var_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/variance",
+			NRMetric:    fmt.Sprintf("var_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	case "median":
 		queryParams = &BitmovinQueryParams{
-			URI:         	"/v1/analytics/queries/median",
-			NRMetric:    	fmt.Sprintf("med_%s", strings.ToLower(query.Metric)),
-			Metric:			"",
-			BMDimension: 	query.Metric,
-			Filters:     	buildFilters(query),
-			GroupBy:	 	buildGroupBy(query),
-			Interval:    	getInterval(query),
-			OrderBy:     	buildOrderBy(query),
+			URI:         "/v1/analytics/queries/median",
+			NRMetric:    fmt.Sprintf("med_%s", strings.ToLower(query.Metric)),
+			Metric:      "",
+			BMDimension: query.Metric,
+			Filters:     buildFilters(query),
+			GroupBy:     buildGroupBy(query),
+			Interval:    getInterval(query),
+			OrderBy:     buildOrderBy(query),
 		}
 	}
 


### PR DESCRIPTION
# Description

New Relic metric names are generated based on the combination of Bitmovin metric type and Bitmovin metric name, as specified in the config yaml file. That's problematic, because it assumes we can only generate one New Relic metric per one combination of Bitmovin type+metric, which is false: we can have the same type+metric with different groupby, and filters. The result is data collisions: we are sending two different sets of data to New Relic as if they were the same.

# Solution

We added a new field `name` to the query config, so users can define the name they want for each Bitmovin query they define.